### PR TITLE
feat: Make header sticky on kid details page

### DIFF
--- a/src/screens/kid/index.tsx
+++ b/src/screens/kid/index.tsx
@@ -58,8 +58,8 @@ export default function KidPage() {
 
   return (
     <PageContainer>
-      <PageTitle backLink="/kids">
-        <>
+      <div className="sticky top-0 bg-white z-50">
+        <PageTitle backLink="/kids">
           {kid.name}
           <KidLevelChip level={kid.level} />
           <CachedImageInput
@@ -73,45 +73,43 @@ export default function KidPage() {
           >
             📸
           </CachedImageInput>
-        </>
-      </PageTitle>
+        </PageTitle>
 
-      <nav className="flex flex-row justify-between items-center">
-        <FilterLink href="#bookmarked">Épinglés</FilterLink>
-        <FilterLink href="#in-progress">En cours</FilterLink>
-        <FilterLink href="#available">À commencer</FilterLink>
-        <FilterLink href="#validated">Validés</FilterLink>
-      </nav>
-
-      <div>
-        <KidWorkshopsSection
-          id="bookmarked"
-          kid={kid}
-          title="Épinglés"
-          workshops={bookmarkedWorkshops}
-        />
-
-        <KidWorkshopsSection
-          id="in-progress"
-          kid={kid}
-          title="Ateliers en cours"
-          workshops={inProgressWorkshops}
-        />
-
-        <KidWorkshopsSection
-          id="available"
-          kid={kid}
-          title="Ateliers à commencer"
-          workshops={availableWorkshops}
-        />
-
-        <KidWorkshopsSection
-          id="validated"
-          kid={kid}
-          title="Ateliers validés"
-          workshops={validatedWorkshops}
-        />
+        <nav className="flex flex-row justify-between items-center">
+          <FilterLink href="#bookmarked">Épinglés</FilterLink>
+          <FilterLink href="#in-progress">En cours</FilterLink>
+          <FilterLink href="#available">À commencer</FilterLink>
+          <FilterLink href="#validated">Validés</FilterLink>
+        </nav>
       </div>
+
+      <KidWorkshopsSection
+        id="bookmarked"
+        kid={kid}
+        title="Épinglés"
+        workshops={bookmarkedWorkshops}
+      />
+
+      <KidWorkshopsSection
+        id="in-progress"
+        kid={kid}
+        title="Ateliers en cours"
+        workshops={inProgressWorkshops}
+      />
+
+      <KidWorkshopsSection
+        id="available"
+        kid={kid}
+        title="Ateliers à commencer"
+        workshops={availableWorkshops}
+      />
+
+      <KidWorkshopsSection
+        id="validated"
+        kid={kid}
+        title="Ateliers validés"
+        workshops={validatedWorkshops}
+      />
     </PageContainer>
   );
 }


### PR DESCRIPTION
This makes it work but there are a few issues:
- Achor links need to be shifted: maybe doing something like:
```css
html {
  scroll-padding-top: 120px; /* 120 being the header height */
}
```
Or something cleaver.

- The header might deserve some kind of shadow once sticky?
We would need to observe once it becomes sticky... It's not ideal.

I have been thinking of maybe using a backdrop shadow on the header: https://tailwindcss.com/docs/backdrop-blur
It would make it look more like a native app.

- Once the content scroll behind, we can see some shadow  being wider than the header:
![Screenshot 2023-11-05 at 16 57 29](https://github.com/ArnaudRinquin/kids-workshop/assets/1239752/8d97adc1-bc39-46e4-931e-f61f2e846008)

It's not ideal but it's hard to fix in the current layout.

I'm thinking we could maybe add a `header` prop to the `PageContainer`, this way the header could cover 100% of the width, while being set as sticky. Something like:
```js
export function PageContainer({
  children,
  className,
  header,
}: {
  children: React.ReactNode;
  className?: string;
  header: React.ReactNode;
}) {
  return (
    <>
      <PWAHandler />
      <div className="sticky top-0 z-50 backdrop-blur-2xl">
        <div className="container mx-auto p-10">{header}</div>
      </div>
      <div className={classNames("container mx-auto p-10", className)}>
        {children}
      </div>
    </>
  );
}
```

I think this is the way to go for a better design and to bring sticky header to other pages.